### PR TITLE
Will sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ var logger = LarchLogger({
 logger.warn('warn string', {meta: 'object'});
 ```
 
-## Using `willSample($level)`
+## Using `willSample($msg, $level)`
 
 The top level Larch object, as well as each backend, has a method `willSample`.
 This method returns `true` if any backend after this backend in the object tree
@@ -43,7 +43,7 @@ is interested in taking a log with level `$level`. This can be used to avoid
 allocating space for large meta objects, like so:
 
 ```javascript
-if (larch.willSample('warn')) {
+if (larch.willSample('thing failed!', 'warn')) {
     larch.swarn('thing failed!', {
         count: this.count,
         length: this.length,
@@ -59,7 +59,7 @@ to allocate the large meta object.
 Regular log methods (`.log`, `.error`, etc) will first compute a sampling
 decision. Log methods prefixed with an `s` (`.slog`, `.serror`, etc) will use
 a previously computed sampling decision. Calling an `s` method without first
-calling `.willSample($level)` will throw.
+calling `.willSample($msg, $level)` will throw.
 
 # Contributors
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,32 @@ var logger = LarchLogger({
 logger.warn('warn string', {meta: 'object'});
 ```
 
+## Using `willSample($level)`
+
+The top level Larch object, as well as each backend, has a method `willSample`.
+This method returns `true` if any backend after this backend in the object tree
+is interested in taking a log with level `$level`. This can be used to avoid
+allocating space for large meta objects, like so:
+
+```javascript
+if (larch.willSample('warn')) {
+    larch.swarn('thing failed!', {
+        count: this.count,
+        length: this.length,
+        largeArrayOfThings: this.bigArray,
+        hugeAmountOfUsefulDebuggingInfo: this.stuff
+    });
+}
+```
+
+This way, we can do less work when we have a lot of logs because we don't have
+to allocate the large meta object.
+
+Regular log methods (`.log`, `.error`, etc) will first compute a sampling
+decision. Log methods prefixed with an `s` (`.slog`, `.serror`, etc) will use
+a previously computed sampling decision. Calling an `s` method without first
+calling `.willSample($level)` will throw.
+
 # Contributors
 
 * [Russ Frank](http://github.com/rf)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ var logger = LarchLogger({
 logger.warn('warn string', {meta: 'object'});
 ```
 
-## Using `willSample($msg, $level)`
+## Using `willSample($level, $msg)`
 
 The top level Larch object, as well as each backend, has a method `willSample`.
 This method returns `true` if any backend after this backend in the object tree
@@ -43,7 +43,7 @@ is interested in taking a log with level `$level`. This can be used to avoid
 allocating space for large meta objects, like so:
 
 ```javascript
-if (larch.willSample('thing failed!', 'warn')) {
+if (larch.willSample('warn', 'thing failed!')) {
     larch.swarn('thing failed!', {
         count: this.count,
         length: this.length,
@@ -59,7 +59,7 @@ to allocate the large meta object.
 Regular log methods (`.log`, `.error`, etc) will first compute a sampling
 decision. Log methods prefixed with an `s` (`.slog`, `.serror`, etc) will use
 a previously computed sampling decision. Calling an `s` method without first
-calling `.willSample($msg, $level)` will throw.
+calling `.willSample($level, $msg)` will throw.
 
 # Contributors
 

--- a/base-backend.js
+++ b/base-backend.js
@@ -72,7 +72,7 @@ BaseBackend.prototype.slog = function slog(record, cb) {
     this.log(record, cb);
 };
 
-BaseBackend.prototype.willSample = function willSample(msg, level) {
+BaseBackend.prototype.willSample = function willSample(level, msg) {
     return true;
 };
 

--- a/base-backend.js
+++ b/base-backend.js
@@ -41,6 +41,16 @@ function BaseBackend(options) {
     );
 
     assert(
+        typeof self.willSample === 'function',
+        '`willSample` method of BaseBackend must be overridden by function'
+    );
+
+    assert(
+        typeof self.slog === 'function',
+        '`slog` method of BaseBackend must be overridden by function'
+    );
+
+    assert(
         typeof self.bootstrap === 'function',
         '`bootstrap` method of BaseBackend must be overridden by function'
     );
@@ -57,6 +67,14 @@ function BaseBackend(options) {
 }
 
 BaseBackend.prototype.log = function log(record, cb) {};
+
+BaseBackend.prototype.slog = function slog(record, cb) {
+    this.log(record, cb);
+};
+
+BaseBackend.prototype.willSample = function willSample(msg, level) {
+    return true;
+};
 
 BaseBackend.prototype.bootstrap = function bootstrap(cb) {
     cb();

--- a/drop-backend.js
+++ b/drop-backend.js
@@ -38,10 +38,11 @@ function DropBackend(options) {
 
 util.inherits(DropBackend, BaseBackend);
 
-DropBackend.prototype.willSample = function willSample(level) {
+DropBackend.prototype.willSample = function willSample(msg, level) {
     return false;
 };
 
+DropBackend.prototype.slog = 
 DropBackend.prototype.log = function log(record, cb) {
     if (typeof cb === 'function') {
         cb();

--- a/drop-backend.js
+++ b/drop-backend.js
@@ -38,7 +38,7 @@ function DropBackend(options) {
 
 util.inherits(DropBackend, BaseBackend);
 
-DropBackend.prototype.willSample = function willSample(msg, level) {
+DropBackend.prototype.willSample = function willSample(level, msg) {
     return false;
 };
 

--- a/drop-backend.js
+++ b/drop-backend.js
@@ -38,6 +38,10 @@ function DropBackend(options) {
 
 util.inherits(DropBackend, BaseBackend);
 
+DropBackend.prototype.willSample = function willSample(level) {
+    return false;
+};
+
 DropBackend.prototype.log = function log(record, cb) {
     if (typeof cb === 'function') {
         cb();

--- a/larch.js
+++ b/larch.js
@@ -120,15 +120,15 @@ function logMultiBackend(level, msg, meta, cb) {
 };
 
 Larch.prototype.willSampleSingleBackend =
-function willSampleSingleBackend(level) {
-    return self.backends[0].willSample(level);
+function willSampleSingleBackend(msg, level) {
+    return self.backends[0].willSample(msg, level);
 };
 
 Larch.prototype.willSampleMultiBackend =
-function willSampleMultiBackend(level) {
+function willSampleMultiBackend(msg, level) {
     var i;
     for (i = 0; i < this.backends.length; i++) {
-        if (this.backends[i].willSample(level)) {
+        if (this.backends[i].willSample(msg, level)) {
             return true;
         }
     }

--- a/larch.js
+++ b/larch.js
@@ -41,8 +41,10 @@ function Larch(options) {
 
     if (self.backends.length === 1) {
         self.log = self.logSingleBackend;
+        self.willSample = self.willSampleSingleBackend;
     } else {
         self.log = self.logMultiBackend;
+        self.willSample = self.willSampleMultiBackend;
     }
 }
 
@@ -86,6 +88,21 @@ function logMultiBackend(level, msg, meta, cb) {
                 results,
                 'larch.log-multi-backend.many-errors'
             ));
+        }
+    }
+};
+
+Larch.prototype.willSampleSingleBackend =
+function willSampleSingleBackend(level) {
+    return self.backends[0].willSample(level);
+};
+
+Larch.prototype.willSampleMultiBackend =
+function willSampleMultiBackend(level) {
+    var i;
+    for (i = 0; i < this.backends.length; i++) {
+        if (this.backends[i].willSample(level)) {
+            return true;
         }
     }
 };

--- a/larch.js
+++ b/larch.js
@@ -120,15 +120,15 @@ function logMultiBackend(level, msg, meta, cb) {
 };
 
 Larch.prototype.willSampleSingleBackend =
-function willSampleSingleBackend(msg, level) {
-    return self.backends[0].willSample(msg, level);
+function willSampleSingleBackend(level, msg) {
+    return self.backends[0].willSample(level, msg);
 };
 
 Larch.prototype.willSampleMultiBackend =
-function willSampleMultiBackend(msg, level) {
+function willSampleMultiBackend(level, msg) {
     var i;
     for (i = 0; i < this.backends.length; i++) {
-        if (this.backends[i].willSample(msg, level)) {
+        if (this.backends[i].willSample(level, msg)) {
             return true;
         }
     }

--- a/larch.js
+++ b/larch.js
@@ -105,6 +105,8 @@ function willSampleMultiBackend(level) {
             return true;
         }
     }
+
+    return false;
 };
 
 Larch.prototype.bootstrap = function bootstrap(cb) {

--- a/larch.js
+++ b/larch.js
@@ -97,7 +97,6 @@ function slogMultiBackend(level, msg, meta, cb) {
     }
 };
 
-
 Larch.prototype.logMultiBackend =
 function logMultiBackend(level, msg, meta, cb) {
     var self = this;

--- a/level-router-backend.js
+++ b/level-router-backend.js
@@ -116,8 +116,8 @@ LevelRouterBackend.prototype.destroy = function bootstrap(cb) {
     }
 };
 
-LevelRouterBackend.prototype.willSample = function willSample(msg, level) {
-    return this.backends[level].willSample(msg, level);
+LevelRouterBackend.prototype.willSample = function willSample(level, msg) {
+    return this.backends[level].willSample(level, msg);
 };
 
 LevelRouterBackend.prototype.slog = function slog(record, cb) {

--- a/level-router-backend.js
+++ b/level-router-backend.js
@@ -120,6 +120,10 @@ LevelRouterBackend.prototype.willSample = function willSample(level) {
     return this.backends[level].willSample(level);
 };
 
+LevelRouterBackend.prototype.slog = function slog(record, cb) {
+    this.backends[record.data.level].slog(record, cb);
+};
+
 LevelRouterBackend.prototype.log = function log(record, cb) {
     var self = this;
 

--- a/level-router-backend.js
+++ b/level-router-backend.js
@@ -116,6 +116,10 @@ LevelRouterBackend.prototype.destroy = function bootstrap(cb) {
     }
 };
 
+LevelRouterBackend.prototype.willSample = function willSample(level) {
+    return this.backends[level].willSample(level);
+};
+
 LevelRouterBackend.prototype.log = function log(record, cb) {
     var self = this;
 

--- a/level-router-backend.js
+++ b/level-router-backend.js
@@ -116,8 +116,8 @@ LevelRouterBackend.prototype.destroy = function bootstrap(cb) {
     }
 };
 
-LevelRouterBackend.prototype.willSample = function willSample(level) {
-    return this.backends[level].willSample(level);
+LevelRouterBackend.prototype.willSample = function willSample(msg, level) {
+    return this.backends[level].willSample(msg, level);
 };
 
 LevelRouterBackend.prototype.slog = function slog(record, cb) {

--- a/logtron-backend.js
+++ b/logtron-backend.js
@@ -48,6 +48,10 @@ function LogtronBackend(logtron) {
 
 util.inherits(LogtronBackend, BaseBackend);
 
+LogtronBackend.prototype.willSample = function willSample(level) {
+    return true;
+};
+
 LogtronBackend.prototype.destroy = function destroy(cb) {
     var self = this;
 

--- a/logtron-backend.js
+++ b/logtron-backend.js
@@ -48,7 +48,7 @@ function LogtronBackend(logtron) {
 
 util.inherits(LogtronBackend, BaseBackend);
 
-LogtronBackend.prototype.willSample = function willSample(level) {
+LogtronBackend.prototype.willSample = function willSample(msg, level) {
     return true;
 };
 

--- a/logtron-backend.js
+++ b/logtron-backend.js
@@ -58,6 +58,7 @@ LogtronBackend.prototype.destroy = function destroy(cb) {
     self.logtron.close(cb);
 };
 
+LogtronBackend.prototype.slog = 
 LogtronBackend.prototype.log = function log(record, cb) {
     var self = this;
 

--- a/logtron-backend.js
+++ b/logtron-backend.js
@@ -48,7 +48,7 @@ function LogtronBackend(logtron) {
 
 util.inherits(LogtronBackend, BaseBackend);
 
-LogtronBackend.prototype.willSample = function willSample(msg, level) {
+LogtronBackend.prototype.willSample = function willSample(level, msg) {
     return true;
 };
 

--- a/reservoir-backend.js
+++ b/reservoir-backend.js
@@ -192,7 +192,7 @@ ReservoirBackend.prototype.flush = function flush() {
     self.count = 0;
 };
 
-ReservoirBackend.prototype.willSample = function willSample(level) {
+ReservoirBackend.prototype.willSample = function willSample(msg, level) {
     this.samplingDecision = this._makeSamplingDecision(level);
     if (this.samplingDecision !== DO_NOT_SAMPLE) {
         return true;

--- a/reservoir-backend.js
+++ b/reservoir-backend.js
@@ -192,7 +192,7 @@ ReservoirBackend.prototype.flush = function flush() {
     self.count = 0;
 };
 
-ReservoirBackend.prototype.willSample = function willSample(msg, level) {
+ReservoirBackend.prototype.willSample = function willSample(level, msg) {
     this.samplingDecision = this._makeSamplingDecision(level);
     if (this.samplingDecision !== DO_NOT_SAMPLE) {
         return true;

--- a/reservoir-backend.js
+++ b/reservoir-backend.js
@@ -25,6 +25,7 @@ var util = require('util');
 var timers = require('timers');
 var NullStatsd = require('uber-statsd-client/null');
 var extend = require('xtend');
+var typedError = require('error/typed');
 
 var BaseBackend = require('./base-backend');
 var Record = require('./record');
@@ -33,6 +34,12 @@ module.exports = ReservoirBackend;
 
 var DO_NOT_SAMPLE = -1;
 var APPEND_TO_ARRAY = -2;
+
+var SampledLogWithoutSamplingDecision = typedError({
+    type: 'larch.reservoir-backend.sampled-log-without-sampling-decision',
+    message: 'Reservoir backend `slog` method must be called after a call ' +
+        'to ReservoirBackend#willSample'
+});
 
 function ReservoirBackend(options) {
     if (!(this instanceof ReservoirBackend)) {

--- a/reservoir-backend.js
+++ b/reservoir-backend.js
@@ -92,7 +92,7 @@ function ReservoirBackend(options) {
     self.records = [];
     self.dropCount = {};
     self.logCount = {};
-    self.samplingDecision = NaN;
+    self.samplingDecision = null;
 }
 
 util.inherits(ReservoirBackend, BaseBackend);
@@ -227,7 +227,7 @@ ReservoirBackend.prototype.log = function log(record, cb) {
 
 ReservoirBackend.prototype.slog = function slog(record, cb) {
     // If we don't already have a sampling decision, make one
-    if (Number.isNaN(this.samplingDecision)) {
+    if (this.samplingDecision !== null) {
         this.samplingDecision = this._makeSamplingDecision(record.data.level);
     } 
 
@@ -242,7 +242,7 @@ ReservoirBackend.prototype.slog = function slog(record, cb) {
         this.countDrop(record.data.level);
     }
 
-    this.samplingDecision = NaN;
+    this.samplingDecision = null;
 
     if (typeof cb === 'function') {
         cb();

--- a/test/index.js
+++ b/test/index.js
@@ -22,3 +22,5 @@ require('./errors');
 require('./larch');
 require('./level-router-backend');
 require('./reservoir-backend');
+require('./will-sample');
+

--- a/test/larch.js
+++ b/test/larch.js
@@ -63,7 +63,7 @@ test('larch with muiltple backends uses logMultiBackend', function t2(assert) {
 
     assert.ok(
         logger.log === logger.logMultiBackend,
-        'logger is using logSingleBackend'
+        'logger is using logMultiBackend'
     );
 
     logger.error('test', {foo: 'bar'});
@@ -84,6 +84,25 @@ test('larch with muiltple backends uses logMultiBackend', function t2(assert) {
         jsonRecord2,
         {foo: 'bar', message: 'test', level: 'error'},
         'log backend 2 gets message'
+    );
+
+    assert.end();
+});
+
+test('calling Larch#slog correctly calls $Backend#slog', function t3(assert) {
+    var backend = FakeBackend();
+
+    var logger = Larch({backends: [backend]});
+
+    logger.slog('warn', 'test', {foo: 'bar'});
+
+    var record = backend.slogs[0].toJSON();
+    delete record.time;
+
+    assert.deepEqual(
+        record,
+        {foo: 'bar', message: 'test', level: 'warn'},
+        'backend#slog receives record'
     );
 
     assert.end();

--- a/test/lib/fake-backend.js
+++ b/test/lib/fake-backend.js
@@ -31,6 +31,7 @@ function FakeBackend(options) {
         return new FakeBackend(options);
     }
     this.logs = [];
+    this.slogs = [];
     this.bootstrapped = false;
     this.destroyed = false;
 }
@@ -39,6 +40,14 @@ util.inherits(FakeBackend, BaseBackend);
 
 FakeBackend.prototype.log = function log(record, cb) {
     this.logs.push(record);
+
+    if (typeof cb === 'function') {
+        cb();
+    }
+};
+
+FakeBackend.prototype.slog = function slog(record, cb) {
+    this.slogs.push(record);
 
     if (typeof cb === 'function') {
         cb();

--- a/test/will-sample.js
+++ b/test/will-sample.js
@@ -29,8 +29,14 @@ var Record = require('../record');
 var FakeBackend = require('./lib/fake-backend');
 
 test('ReservoirBackend willSample is accurate', function t1(assert) {
+    var time = 0;
     function fakeRangeRand(lo, hi) {
-        return 6;
+        time += 1;
+        if (time === 1) {
+            return 6;
+        } else {
+            return 0;
+        }
     }
 
     var backend = FakeBackend();
@@ -50,17 +56,17 @@ test('ReservoirBackend willSample is accurate', function t1(assert) {
     var samplingDecisions = [];
 
     samplingDecisions[0] = reservoir.willSample('error');
-    reservoir.log(new Record('error', 'timed out', {}));
+    reservoir.slog(new Record('error', 'timed out', {}));
     samplingDecisions[1] = reservoir.willSample('error');
-    reservoir.log(new Record('error', 'timed out', {}));
+    reservoir.slog(new Record('error', 'timed out', {}));
     samplingDecisions[2] = reservoir.willSample('error');
-    reservoir.log(new Record('error', 'timed out', {}));
+    reservoir.slog(new Record('error', 'timed out', {}));
     samplingDecisions[3] = reservoir.willSample('error');
-    reservoir.log(new Record('error', 'timed out', {}));
+    reservoir.slog(new Record('error', 'timed out', {}));
     samplingDecisions[4] = reservoir.willSample('error');
-    reservoir.log(new Record('error', 'timed out', {}));
+    reservoir.slog(new Record('error', 'timed out', {}));
     samplingDecisions[5] = reservoir.willSample('error');
-    reservoir.log(new Record('warn', 'thing failed', {}));
+    reservoir.slog(new Record('warn', 'thing failed', {}));
 
     console.log('samplingDecisions', samplingDecisions);
     assert.deepEqual(samplingDecisions, [true, true, true, true, true, false]);

--- a/test/will-sample.js
+++ b/test/will-sample.js
@@ -1,0 +1,111 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var test = require('tape');
+var Timer = require('time-mock');
+
+var ReservoirBackend = require('../reservoir-backend');
+var Record = require('../record');
+
+var FakeBackend = require('./lib/fake-backend');
+
+test('ReservoirBackend willSample is accurate', function t1(assert) {
+    function fakeRangeRand(lo, hi) {
+        return 6;
+    }
+
+    var backend = FakeBackend();
+    var timer = Timer(0);
+
+    var reservoir = ReservoirBackend({
+        backend: backend,
+        size: 5,
+        timers: timer,
+        rangeRand: fakeRangeRand
+    });
+
+    reservoir.bootstrap(noop);
+
+    assert.ok(backend.bootstrapped, 'backend was bootstrapped');
+
+    var samplingDecisions = [];
+
+    samplingDecisions[0] = reservoir.willSample('error');
+    reservoir.log(new Record('error', 'timed out', {}));
+    samplingDecisions[1] = reservoir.willSample('error');
+    reservoir.log(new Record('error', 'timed out', {}));
+    samplingDecisions[2] = reservoir.willSample('error');
+    reservoir.log(new Record('error', 'timed out', {}));
+    samplingDecisions[3] = reservoir.willSample('error');
+    reservoir.log(new Record('error', 'timed out', {}));
+    samplingDecisions[4] = reservoir.willSample('error');
+    reservoir.log(new Record('error', 'timed out', {}));
+    samplingDecisions[5] = reservoir.willSample('error');
+    reservoir.log(new Record('warn', 'thing failed', {}));
+
+    console.log('samplingDecisions', samplingDecisions);
+    assert.deepEqual(samplingDecisions, [true, true, true, true, true, false]);
+
+    timer.advance(50);
+
+    assert.ok(reservoir.records.length === 0, 'reservoir was flushed');
+    assert.ok(backend.logs.length === 6, 'only 6 logs got through to backend');
+
+    assert.ok(
+        backend.logs[0].data.message === 'dropped logs' &&
+        backend.logs[0].data.level === 'warn',
+        'first log is dropped log warn'
+    );
+
+    assert.deepEquals(
+        backend.logs[0].meta,
+        {dropCount: {warn: 1}, flushInterval: 50, size: 5},
+        'first log contains correct meta'
+    );
+
+    assert.ok(
+        backend.logs[1].data.message === 'timed out',
+        'logs[1] is right'
+    );
+    assert.ok(
+        backend.logs[2].data.message === 'timed out',
+        'logs[2] is right'
+    );
+    assert.ok(
+        backend.logs[3].data.message === 'timed out',
+        'logs[3] is right'
+    );
+    assert.ok(
+        backend.logs[4].data.message === 'timed out',
+        'logs[4] is right'
+    );
+    assert.ok(
+        backend.logs[5].data.message === 'timed out',
+        'logs[5] is right'
+    );
+
+    reservoir.destroy(noop);
+
+    assert.end();
+});
+
+function noop() {}

--- a/test/will-sample.js
+++ b/test/will-sample.js
@@ -114,4 +114,21 @@ test('ReservoirBackend willSample is accurate', function t1(assert) {
     assert.end();
 });
 
+test('ReservoirBackend slog throws without sampling decision', function t2(assert) {
+    var backend = FakeBackend();
+    var timer = Timer(0);
+
+    var reservoir = ReservoirBackend({
+        backend: backend,
+        size: 5,
+        timers: timer
+    });
+
+    assert.throws(function callSlog() {
+        reservoir.slog('warn', 'message', {});
+    }, /Reservoir backend `slog` method must be called after/);
+
+    assert.end();
+});
+
 function noop() {}


### PR DESCRIPTION
Took a stab at will sample. Any backend aggregators (top level, level router) will need to take the log if any of their backends want it. The reservoir sampler will make a sampling decision and store it and use it for the next log it gets.

Code that uses `willSample` will use the `s` prefixed log methods, which use the previously decided sampling decision rather than making one.

Alternatively we could return an opaque value (which would really be a tree of objects). Other than that we would have to restrict the functionality of Larch in order to fit the sampling decisions into a smaller value (like a SMI).

r @Raynos @jcorbin 