### PR TITLE
Allow global statsd for cluster-wide latency

### DIFF
--- a/reservoir-backend.js
+++ b/reservoir-backend.js
@@ -101,7 +101,7 @@ function ReservoirBackend(options) {
         };
     }
 
-    this.globalStatsd = options.globalStatsd || null;
+    this.clusterStatsd = options.clusterStatsd || null;
 
     this.timer = null;
     this.count = 0;
@@ -199,8 +199,8 @@ ReservoirBackend.prototype.flush = function flush() {
 
         var flushDelta = self.now() - start;
         self.statsd.timing('larch.flushTime', flushDelta);
-        if (self.globalStatsd) {
-            self.globalStatsd.timing('larch.flushTime', flushDelta);
+        if (self.clusterStatsd) {
+            self.clusterStatsd.timing('larch.flushTime', flushDelta);
         }
     }
 

--- a/reservoir-backend.js
+++ b/reservoir-backend.js
@@ -101,6 +101,8 @@ function ReservoirBackend(options) {
         };
     }
 
+    this.globalStatsd = options.globalStatsd || null;
+
     this.timer = null;
     this.count = 0;
     this.records = [];
@@ -195,7 +197,11 @@ ReservoirBackend.prototype.flush = function flush() {
             self.statsd.increment('larch.errors', count);
         }
 
-        self.statsd.timing('larch.flushTime', self.now() - start);
+        var flushDelta = self.now() - start;
+        self.statsd.timing('larch.flushTime', flushDelta);
+        if (self.globalStatsd) {
+            self.globalStatsd.timing('larch.flushTime', flushDelta);
+        }
     }
 
     self.records.length = 0;

--- a/test/reservoir-backend.js
+++ b/test/reservoir-backend.js
@@ -102,7 +102,7 @@ test('reservoirbackend uses statsd client correctly', function t1(assert) {
     var backend = FakeBackend();
     var timer = Timer(0);
     var statsd = new NullStatsd();
-    var globalStatsd = new NullStatsd();
+    var clusterStatsd = new NullStatsd();
 
     var reservoir = ReservoirBackend({
         backend: backend,
@@ -110,7 +110,7 @@ test('reservoirbackend uses statsd client correctly', function t1(assert) {
         timers: timer,
         rangeRand: fakeRangeRand,
         statsd: statsd,
-        globalStatsd: globalStatsd
+        clusterStatsd: clusterStatsd
     });
 
     reservoir.bootstrap(noop);
@@ -196,8 +196,8 @@ test('reservoirbackend uses statsd client correctly', function t1(assert) {
         'correct statsd records'
     );
 
-    delete globalStatsd._buffer._elements[0].time;
-    assert.deepEqual(globalStatsd._buffer._elements[0], {
+    delete clusterStatsd._buffer._elements[0].time;
+    assert.deepEqual(clusterStatsd._buffer._elements[0], {
         type: 'ms',
         name: 'larch.flushTime',
         value: null,

--- a/test/reservoir-backend.js
+++ b/test/reservoir-backend.js
@@ -102,13 +102,15 @@ test('reservoirbackend uses statsd client correctly', function t1(assert) {
     var backend = FakeBackend();
     var timer = Timer(0);
     var statsd = new NullStatsd();
+    var globalStatsd = new NullStatsd();
 
     var reservoir = ReservoirBackend({
         backend: backend,
         size: 5,
         timers: timer,
         rangeRand: fakeRangeRand,
-        statsd: statsd
+        statsd: statsd,
+        globalStatsd: globalStatsd
     });
 
     reservoir.bootstrap(noop);
@@ -193,6 +195,14 @@ test('reservoirbackend uses statsd client correctly', function t1(assert) {
         }],
         'correct statsd records'
     );
+
+    delete globalStatsd._buffer._elements[0].time;
+    assert.deepEqual(globalStatsd._buffer._elements[0], {
+        type: 'ms',
+        name: 'larch.flushTime',
+        value: null,
+        delta: null
+    });
 
     reservoir.destroy(noop);
 

--- a/test/will-sample.js
+++ b/test/will-sample.js
@@ -68,7 +68,6 @@ test('ReservoirBackend willSample is accurate', function t1(assert) {
     samplingDecisions[5] = reservoir.willSample('error');
     reservoir.slog(new Record('warn', 'thing failed', {}));
 
-    console.log('samplingDecisions', samplingDecisions);
     assert.deepEqual(samplingDecisions, [true, true, true, true, true, false]);
 
     timer.advance(50);


### PR DESCRIPTION
This change adds a `globalStatsd` so we can track cluster-wide flush
time P99.

r: @rf @kriskowal @Matt-Esch