### PR TITLE
reservoir-backend: add sync flush latency

### DIFF
--- a/reservoir-backend.js
+++ b/reservoir-backend.js
@@ -186,6 +186,12 @@ ReservoirBackend.prototype.flush = function flush() {
     var copy = self.records.slice(0);
     self.backend.logMany(copy, onLoggingDone);
 
+    var syncDelta = self.now() - start;
+    self.statsd.timing('larch.sync.flushTime', syncDelta);
+    if (self.clusterStatsd) {
+        self.clusterStatsd.timing('larch.sync.flushTime', syncDelta);
+    }
+
     function onLoggingDone(err) {
         // TODO: what to do when flush fails? Generate a log message?
         if (err) {

--- a/test/reservoir-backend.js
+++ b/test/reservoir-backend.js
@@ -163,9 +163,10 @@ test('reservoirbackend uses statsd client correctly', function t1(assert) {
     );
 
     delete statsd._buffer._elements[3].time;
+    delete statsd._buffer._elements[4].time;
 
     assert.deepEqual(
-        statsd._buffer._elements.slice(0, 4),
+        statsd._buffer._elements.slice(0, 5),
         [{
             type: 'c',
             name: 'larch.dropped.error',
@@ -190,6 +191,12 @@ test('reservoirbackend uses statsd client correctly', function t1(assert) {
         {
             type: 'ms',
             name: 'larch.flushTime',
+            value: null,
+            delta: null
+        },
+        {
+            type: 'ms',
+            name: 'larch.sync.flushTime',
             value: null,
             delta: null
         }],


### PR DESCRIPTION
This allows us to see how time was spent in serialization

r: @rf @Matt-Esch @zhijin